### PR TITLE
Add tests to improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.sw[po]
 vendor
 *.out
+*.html

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 *.sw[po]
 vendor
+*.out

--- a/actually_test.go
+++ b/actually_test.go
@@ -100,3 +100,8 @@ func TestName(t *testing.T) {
 	aaa := Got(aa.name).Expect("bar").Name("baz").Same(t, "aiko")
 	Got(aaa.name).Expect("baz, aiko").Same(t)
 }
+
+func TestShowRawData(t *testing.T) {
+	a := Got("beer").Expect("deer").ShowRawData()
+	Got(a.showRawData).True(t)
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -2,9 +2,10 @@ package diff
 
 import (
 	"testing"
+	"time"
 )
 
-func TestDiff(t *testing.T) {
+func TestDiffStruct(t *testing.T) {
 	type S struct {
 		id   int
 		name string
@@ -19,7 +20,7 @@ func TestDiff(t *testing.T) {
 		name: "eiko",
 	}
 
-	got := "\n" + Diff(a, b) // "\n" is for heredoc.
+	got := "\n" + Diff(a, b) // "\n" is for comparing to heredoc.
 	expect := `
 --- Expected
 +++ Actually got
@@ -33,5 +34,54 @@ func TestDiff(t *testing.T) {
 `
 	if got != expect {
 		t.Errorf("Diff was wrong.\n[Got]\n%s\n\n[Expect]\n%s\n", got, expect)
+	}
+}
+
+func TestDiffString(t *testing.T) {
+	a := "beer"
+	b := "deer"
+
+	got := "\n" + Diff(a, b)
+	expect := `
+--- Expected
++++ Actually got
+@@ -1 +1 @@
+-beer
++deer
+`
+	if got != expect {
+		t.Errorf("Diff was wrong.\n[Got]\n%s\n\n[Expect]\n%s\n", got, expect)
+	}
+}
+
+func TestDiffTime(t *testing.T) {
+	a := time.Date(2023, 4, 23, 0, 0, 0, 0, time.UTC)
+	b := time.Date(2023, 4, 24, 0, 0, 0, 0, time.UTC)
+
+	got := "\n" + Diff(a, b)
+	expect := `
+--- Expected
++++ Actually got
+@@ -1,2 +1,2 @@
+-(time.Time) 2023-04-23 00:00:00 +0000 UTC
++(time.Time) 2023-04-24 00:00:00 +0000 UTC
+ 
+` // What is last space? It would be created by difflib.GetUnifiedDiffString?? Anyway, I ignore :-)
+	if got != expect {
+		t.Errorf("Diff was wrong.\n[Got]\n%#v\n\n[Expect]\n%#v\n", got, expect)
+	}
+}
+
+func TestDiffNil(t *testing.T) {
+	if Diff(nil, nil) != "" {
+		t.Error("<nil> input should be blank string")
+	}
+
+	if Diff(1, "string") != "" {
+		t.Error("Input values should be same type")
+	}
+
+	if Diff(1, 2) != "" {
+		t.Error("NOT supported int type")
 	}
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -14,3 +14,67 @@ func TestReport(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestSetter(t *testing.T) {
+	r := New()
+
+	r = r.Trace("t")
+	if r.trace != "t" {
+		t.Errorf("Wrong Trace(): %#v", r.trace)
+	}
+
+	r = r.Function("f")
+	if r.function != "f" {
+		t.Errorf("Wrong Function(): %#v", r.function)
+	}
+
+	r = r.Name("n")
+	if r.name != "n" {
+		t.Errorf("Wrong Name(): %#v", r.name)
+	}
+
+	r = r.Reason("r")
+	if r.reason != "r" {
+		t.Errorf("Wrong Reason(): %#v", r.reason)
+	}
+
+	r = r.Notice("notice")
+	if r.notice != "notice" {
+		t.Errorf("Wrong Notice(): %#v", r.notice)
+	}
+	r = r.Noticef("notice:%s", "Keira")
+	if r.notice != "notice:Keira" {
+		t.Errorf("Wrong Noticef(): %#v", r.notice)
+	}
+
+	r = r.Got("g")
+	if r.got != "g" {
+		t.Errorf("Wrong Got(): %#v", r.got)
+	}
+	r = r.Gotf("gf")
+	if r.got != "gf" {
+		t.Errorf("Wrong Gotf(): %#v", r.got)
+	}
+	r = r.GotAsString("gs")
+	if r.gotAsString != "gs" {
+		t.Errorf("Wrong GotAsString(): %#v", r.gotAsString)
+	}
+
+	r = r.Expect("e")
+	if r.expect != "e" {
+		t.Errorf("Wrong Expect(): %#v", r.expect)
+	}
+	r = r.Expectf("ef")
+	if r.expect != "ef" {
+		t.Errorf("Wrong Expectf(): %#v", r.expect)
+	}
+	r = r.ExpectAsString("es")
+	if r.expectAsString != "es" {
+		t.Errorf("Wrong ExpectAsString(): %#v", r.expectAsString)
+	}
+
+	r = r.Diff("d")
+	if r.diff != "d" {
+		t.Errorf("Wrong Diff(): %#v", r.diff)
+	}
+}

--- a/same_util_test.go
+++ b/same_util_test.go
@@ -5,11 +5,30 @@ import (
 	"time"
 )
 
-// func TestReportForSame(t *testing.T) {
-// 	a := Got("Hello.\nThanks!").Expect("Hello.\nThank you!").ShowRawData()
-// 	out := reportForSame(a).Put()
-// 	fmt.Print(out)
-// }
+func TestReportForSame(t *testing.T) {
+	a := Got("EGLL").Expect("LHR")
+	Got(reportForSame(a).Put()).
+		Expect("\tExpected:    \tDump: \"LHR\"\n\tActually got:\tDump: \"EGLL\"\n").
+		ShowRawData().
+		Same(t)
+
+	aa := Got(128).Expect(256)
+	Got(reportForSame(aa).Put()).
+		Expect("\tExpected:    \tType: int, Dump: 256\n\tActually got:\tType: int, Dump: 128\n").
+		ShowRawData().
+		Same(t)
+}
+
+func TestReportForSameWithDiff(t *testing.T) {
+	a := Got("eiko").Expect("aiko")
+	expect := "\tExpected:    \tDump: \"aiko\"\n\tActually got:\tDump: \"eiko\"\n\t" +
+		"Diff Details:\t--- Expected\n\t             \t+++ Actually got\n" +
+		"\t             \t@@ -1 +1 @@\n\t             \t-aiko\n\t             \t+eiko\n"
+	Got(reportForSameWithDiff(a).Put()).
+		Expect(expect).
+		ShowRawData().
+		Same(t)
+}
 
 func TestIsFuncType(t *testing.T) {
 	tts := []struct {
@@ -94,7 +113,9 @@ func TestObjectsAreSameType(t *testing.T) {
 		b      any
 		expect bool
 	}{
+		{name: "<nil>", a: nil, b: nil, expect: true},
 		{name: "Same", a: "a", b: "b", expect: true},
+		{name: "Struct", a: struct{}{}, b: struct{}{}, expect: true},
 		{name: "Number", a: int(7), b: float32(7.0), expect: false},
 		{name: "map", a: map[string]int{}, b: map[string]string{}, expect: false},
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -1,7 +1,17 @@
 // Actual trace_test.go is in ../report directory.
 package trace
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestTraceInfo(t *testing.T) {
+	trace := strings.Join(Info(func(filepath string) bool {return false}), "\n\t")
+	if !strings.Contains(trace, "trace/trace_test.go:10") {
+		t.Errorf("Wrong trace: %#v", trace)
+	}
+}
 
 func TestIsGolangTestFunc(t *testing.T) {
 	if !isGolangTestFunc("TestFoo") {


### PR DESCRIPTION
Before

```
ok      github.com/bayashi/actually     0.003s  coverage: 59.9% of statements
ok      github.com/bayashi/actually/diff        0.001s  coverage: 70.8% of statements
ok      github.com/bayashi/actually/report      0.011s  coverage: 54.4% of statements
ok      github.com/bayashi/actually/trace       0.003s  coverage: 23.7% of statements
```

After this PR

```
ok      github.com/bayashi/actually     0.012s  coverage: 65.9% of statements
ok      github.com/bayashi/actually/diff        0.004s  coverage: 100.0% of statements
ok      github.com/bayashi/actually/report      0.002s  coverage: 86.8% of statements
ok      github.com/bayashi/actually/trace       0.001s  coverage: 86.8% of statements
```
