### PR TITLE
Rename testdata to testobject.

### DIFF
--- a/actually.go
+++ b/actually.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/bayashi/actually/report"
-	"github.com/bayashi/actually/testdata"
+	"github.com/bayashi/actually/testobject"
 	"github.com/bayashi/actually/trace"
 )
 
 type testingA struct {
-	got         *testdata.TestData
+	got         *testobject.TestObject
 	setGot      bool
-	expect      *testdata.TestData
+	expect      *testobject.TestObject
 	setExpect   bool
 	t           *testing.T
 	failNow     bool
@@ -24,7 +24,7 @@ type testingA struct {
 // `Got` sets the value you actually got.
 func Got(g any) *testingA {
 	return &testingA{
-		got:    testdata.NewTestData(g, 0),
+		got:    testobject.NewTestObject(g, 0),
 		setGot: true,
 	}
 }
@@ -34,7 +34,7 @@ func (a *testingA) Got(g any) *testingA {
 		panic(panicReason_CalledGotTwice)
 	}
 
-	a.got = testdata.NewTestData(g, 0)
+	a.got = testobject.NewTestObject(g, 0)
 	a.setGot = true
 
 	return a
@@ -43,7 +43,7 @@ func (a *testingA) Got(g any) *testingA {
 // `Expect` sets the value you expect to be the same as the one you got.
 func Expect(e any) *testingA {
 	return &testingA{
-		expect:    testdata.NewTestData(e, 0),
+		expect:    testobject.NewTestObject(e, 0),
 		setExpect: true,
 	}
 }
@@ -53,7 +53,7 @@ func (a *testingA) Expect(e any) *testingA {
 		panic(panicReason_CalledExpectTwice)
 	}
 
-	a.expect = testdata.NewTestData(e, 0)
+	a.expect = testobject.NewTestObject(e, 0)
 	a.setExpect = true
 
 	return a

--- a/testobject/testobject.go
+++ b/testobject/testobject.go
@@ -1,5 +1,5 @@
-// testdata package provides utilities to handle data of testing
-package testdata
+// testobject package provides utilities to handle data of testing
+package testobject
 
 import (
 	"bufio"
@@ -9,12 +9,12 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-type TestData struct {
+type TestObject struct {
 	value  any
 	maxLen int
 }
 
-func NewTestData(v any, maxLen int) *TestData {
+func NewTestObject(v any, maxLen int) *TestObject {
 	max := bufio.MaxScanTokenSize
 	if maxLen < 0 {
 		maxLen = max + maxLen
@@ -22,17 +22,17 @@ func NewTestData(v any, maxLen int) *TestData {
 		maxLen = bufio.MaxScanTokenSize
 	}
 
-	return &TestData{
+	return &TestObject{
 		value:  v,
 		maxLen: maxLen,
 	}
 }
 
-func (td *TestData) RawValue() any {
+func (td *TestObject) RawValue() any {
 	return td.value
 }
 
-func (td *TestData) IsStringType() bool {
+func (td *TestObject) IsStringType() bool {
 	if v := td.RawValue(); v != nil {
 		k := reflect.ValueOf(v).Kind()
 		if k == reflect.String {
@@ -43,7 +43,7 @@ func (td *TestData) IsStringType() bool {
 	return false
 }
 
-func (td *TestData) IsDumpableRawType() bool {
+func (td *TestObject) IsDumpableRawType() bool {
 	if v := td.RawValue(); v != nil {
 		k := reflect.ValueOf(v).Kind()
 		if k == reflect.Struct || k == reflect.Map || k == reflect.Slice || k == reflect.Array {
@@ -54,12 +54,12 @@ func (td *TestData) IsDumpableRawType() bool {
 	return false
 }
 
-func (td *TestData) Dump() string {
+func (td *TestObject) Dump() string {
 	return spew.Sdump(td.RawValue())
 }
 
 // For `fmt/print.go` Formatter interface
-func (td *TestData) Format(s fmt.State, verb rune) {
+func (td *TestObject) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		flag := ""

--- a/testobject/testobject_test.go
+++ b/testobject/testobject_test.go
@@ -1,4 +1,4 @@
-package testdata
+package testobject
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ type Example struct {
 
 func TestTruncate(t *testing.T) {
 	len := 10
-	td := NewTestData(&Example{id: 12, name: "John Doe"}, len)
+	td := NewTestObject(&Example{id: 12, name: "John Doe"}, len)
 
 	tts := []struct {
 		format string
@@ -20,9 +20,9 @@ func TestTruncate(t *testing.T) {
 	}{
 		{format: "%v", expect: "&{12 John <... truncated>"},
 		{format: "%+v", expect: "&{id:12 na<... truncated>"},
-		{format: "%#v", expect: "&testdata.<... truncated>"},
+		{format: "%#v", expect: "&testobjec<... truncated>"},
 		{format: "%s", expect: "&{%!s(int=<... truncated>"},
-		{format: "%Y", expect: "*testdata.Example"}, // The type of RawValue()
+		{format: "%Y", expect: "*testobject.Example"}, // The type of RawValue()
 	}
 	for _, tt := range tts {
 		if got := fmt.Sprintf(tt.format, td); got != tt.expect {
@@ -32,32 +32,32 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestRawValue(t *testing.T) {
-	td := NewTestData("John Doe", 1024)
+	td := NewTestObject("John Doe", 1024)
 	if td.RawValue() != "John Doe" {
 		t.Error("RawValue() was wrong")
 	}
 }
 
 func TestIsStringType(t *testing.T) {
-	if td := NewTestData("John Doe", 1024); !td.IsStringType() {
+	if td := NewTestObject("John Doe", 1024); !td.IsStringType() {
 		t.Error("IsStringType() was wrong")
 	}
-	if td := NewTestData(7, 1024); td.IsStringType() {
+	if td := NewTestObject(7, 1024); td.IsStringType() {
 		t.Error("IsStringType() was wrong")
 	}
 }
 
 func TestIsDumpableRawType(t *testing.T) {
-	if td := NewTestData([]int{1, 2}, 1024); !td.IsDumpableRawType() {
+	if td := NewTestObject([]int{1, 2}, 1024); !td.IsDumpableRawType() {
 		t.Error("IsDumpableRawType() was wrong")
 	}
-	if td := NewTestData(7, 1024); td.IsDumpableRawType() {
+	if td := NewTestObject(7, 1024); td.IsDumpableRawType() {
 		t.Error("IsDumpableRawType() was wrong")
 	}
 }
 
 func TestDump(t *testing.T) {
-	td := NewTestData(123, 1024)
+	td := NewTestObject(123, 1024)
 	if td.Dump() != "(int) 123\n" {
 		t.Error("Dump() was wrong")
 	}


### PR DESCRIPTION
`testdata` is special name in Go to store test data. It's skipped in test

> The go tool will ignore a directory named "testdata", making it available
to hold ancillary data needed by the tests.
https://pkg.go.dev/cmd/go/internal/test