### PR TITLE
Fix SameNumber() method.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -21,6 +21,8 @@ const (
 	reason_ExpectIsNotPointer    = "`Expect` is NOT type of Pointer"
 	reason_GotIsNilType          = "Type of `Got` is a <nil> value"
 	reason_ExpectIsNilType       = "Type of `Expect` is a <nil> value"
+	reason_GotIsNotNumber        = "Type of `Got` is not a number"
+	reason_ExpectIsNotNumber     = "Type of `Expect` is not a number"
 	reason_ExpectIsNotNil        = "Expected other than <nil>, but got <nil>"
 	reason_ExpectIsNotValidValue = "`Expect` value is NOT a valid value"
 	reason_NotConvertibleTypes   = "The types of `Got` and `Expect` are NOT convertible"
@@ -28,7 +30,7 @@ const (
 	// notice_Method_*
 	notice_Same_NotAcceptable        = "It's not acceptable in Same() method"
 	notice_SamePointer_ShouldPointer = "It should be a Pointer for SamePointer() method"
-	notice_SameNumber_ShouldNumber   = "It should be a number for SameNumber() method"
+	notice_SameNumber_ShouldNumber   = "It should be a number(int or float) for SameNumber() method"
 
 	template_Dump            = "Type: %Y, Dump: %#v"
 	template_DumpStringType  = "Dump: %#v"

--- a/same.go
+++ b/same.go
@@ -82,15 +82,18 @@ func (a *TestingA) SameNumber(t *testing.T, testNames ...string) *TestingA {
 	got := a.got.RawValue()
 	expect := a.expect.RawValue()
 
-	if !isFuncType(got) && !isFuncType(expect) && objectsAreSame(expect, got) {
-		return a // Pass
-	}
-
 	if isTypeNil(got) {
 		return a.fail(reportForSame(a).Reason(reason_GotIsNilType).Notice(notice_SameNumber_ShouldNumber))
 	}
 	if isTypeNil(expect) {
 		return a.fail(reportForSame(a).Reason(reason_ExpectIsNilType).Notice(notice_SameNumber_ShouldNumber))
+	}
+
+	if !isTypeNumber(got) {
+		return a.fail(reportForSame(a).Reason(reason_GotIsNotNumber).Notice(notice_SameNumber_ShouldNumber))
+	}
+	if !isTypeNumber(expect) {
+		return a.fail(reportForSame(a).Reason(reason_ExpectIsNotNumber).Notice(notice_SameNumber_ShouldNumber))
 	}
 
 	if !isValidValue(expect) {

--- a/same_test.go
+++ b/same_test.go
@@ -77,7 +77,11 @@ func TestSameNumber(t *testing.T) {
 	// fail
 	// actually.Got("1").Expect(1).SameNumber(t)
 	// actually.Got(1).Expect("1").SameNumber(t)
+	// actually.Got(nil).Expect(nil).SameNumber(t)
 	// actually.Got(nil).Expect(0).SameNumber(t)
+	// actually.Got(0).Expect(nil).SameNumber(t)
+	// actually.Got([]byte("0")).Expect([]byte("0")).SameNumber(t)
+	// actually.Got("0").Expect("0").SameNumber(t)
 }
 
 func TestChain(t *testing.T) {

--- a/same_util.go
+++ b/same_util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/bayashi/actually/diff"
 	"github.com/bayashi/actually/report"
@@ -68,6 +69,11 @@ func isTypeNil(v any) bool {
 
 func isValidValue(v any) bool {
 	return reflect.ValueOf(v).IsValid()
+}
+
+func isTypeNumber(v any) bool {
+	typ := reflect.TypeOf(v).Name()
+	return strings.HasPrefix(typ, "int") || strings.HasPrefix(typ, "float")
 }
 
 // Just confirming only types are convertible or not


### PR DESCRIPTION
There were cases that a test unintentionally passed on when the test values are not number, but these are same.