### PR TITLE
Improve test name

### DIFF
--- a/actually_util.go
+++ b/actually_util.go
@@ -45,12 +45,12 @@ func (a *TestingA) naming(testNames ...string) string {
 		if len(testNames) > 0 {
 			n := []string{a.name}
 			n = append(n, testNames...)
-			return strings.Join(n, ", ")
+			return strings.Join(n, ".")
 		} else {
 			return a.name
 		}
 	} else {
-		return strings.Join(testNames, ", ")
+		return strings.Join(testNames, ".")
 	}
 }
 

--- a/actually_util_test.go
+++ b/actually_util_test.go
@@ -43,12 +43,12 @@ func TestNaming(t *testing.T) {
 		t.Errorf("Expect `%s`, but got `%s`", expect, n)
 	}
 
-	expect2 := "Name, FooTest"
+	expect2 := "Name.FooTest"
 	if n := Got(12).Name("Name").naming(expect); n != expect2 {
 		t.Errorf("Expect `%s`, but got `%s`", expect2, n)
 	}
 
-	if n := Got(12).Name("Name").naming(expect, expect); n != expect2+", "+expect {
+	if n := Got(12).Name("Name").naming(expect, expect); n != expect2+"."+expect {
 		t.Errorf("Expect `%s`, but got `%s`", expect2+", "+expect, n)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 require github.com/pmezard/go-difflib v1.0.0 // indirect
 
-require github.com/bayashi/witness v0.0.15
+require github.com/bayashi/witness v0.0.16
 
 require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bayashi/witness v0.0.15 h1:M9pDXYWMth0z8L32/nNxdfx3v+W7v1jP1KG767wAFK8=
-github.com/bayashi/witness v0.0.15/go.mod h1:xxXU08y35qzkp0kDRGVYuvHB5JVxFKe6vF16puu7gEo=
+github.com/bayashi/witness v0.0.16 h1:QEb2mdPbzXmlZBJqMJYji72t5Do3qYmj/sid5mGbTg4=
+github.com/bayashi/witness v0.0.16/go.mod h1:xxXU08y35qzkp0kDRGVYuvHB5JVxFKe6vF16puu7gEo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -15,7 +15,7 @@ func TestTestName(t *testing.T) {
 	a := Got(1).Name("foo").NotNil(t)
 	aa := Got(a.name).Expect("foo").Same(t, "bar")
 	aaa := Got(aa.name).Expect("bar").Name("baz").Same(t, "aiko")
-	Got(aaa.name).Expect("baz, aiko").Same(t)
+	Got(aaa.name).Expect("baz.aiko").Same(t)
 }
 
 func TestX(t *testing.T) {

--- a/same.go
+++ b/same.go
@@ -17,8 +17,7 @@ func (a *TestingA) Same(t *testing.T, testNames ...string) *TestingA {
 	a.t = t
 	a.t.Helper()
 
-	got := a.got
-	expect := a.expect
+	got, expect := a.got, a.expect
 
 	if !objectsAreSameType(expect, got) {
 		return a.fail(reportForSame(a), reason_WrongType)
@@ -43,8 +42,7 @@ func (a *TestingA) SamePointer(t *testing.T, testNames ...string) *TestingA {
 	a.t = t
 	a.t.Helper()
 
-	got := a.got
-	expect := a.expect
+	got, expect := a.got, a.expect
 
 	if !isPointerType(got) {
 		w := reportForSame(a).Message(notice_Label, notice_SamePointer_ShouldPointer)
@@ -79,8 +77,7 @@ func (a *TestingA) SameNumber(t *testing.T, testNames ...string) *TestingA {
 	a.t = t
 	a.t.Helper()
 
-	got := a.got
-	expect := a.expect
+	got, expect := a.got, a.expect
 
 	if isTypeNil(got) {
 		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)

--- a/same_test.go
+++ b/same_test.go
@@ -46,9 +46,7 @@ func TestSame(t *testing.T) {
 			expected: struct{ bar string }{bar: "foo"}, actuallyGot: struct{ bar string }{bar: "foo"},
 		},
 	} {
-		t.Run(tn, func(t *testing.T) {
-			Got(tt.actuallyGot).Expect(tt.expected).Same(t)
-		})
+		Got(tt.actuallyGot).Expect(tt.expected).Same(t, tn)
 	}
 
 	// `foo` and `bar` are same value. But these pointer addresses are different in fact.
@@ -88,11 +86,9 @@ func TestSame_Fail(t *testing.T) {
 			expected: func() {}, actuallyGot: func() {}, expectedFailReason: reason_GotIsFunc,
 		},
 	} {
-		t.Run(tn, func(t *testing.T) {
-			stubConfirm(t, func() {
-				Got(tt.actuallyGot).Expect(tt.expected).Same(t)
-			}, tt.expectedFailReason)
-		})
+		stubConfirm(t, func() {
+			Got(tt.actuallyGot).Expect(tt.expected).Same(t, tn)
+		}, tt.expectedFailReason)
 	}
 }
 
@@ -144,9 +140,7 @@ func TestSameNumber(t *testing.T) {
 		// 	expected: complex64(1e+10 + 1e+10i), actuallyGot: complex128(1e+10 + 1e+10i),
 		// },
 	} {
-		t.Run(tn, func(t *testing.T) {
-			Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t)
-		})
+		Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
 	}
 
 	// test name
@@ -174,11 +168,9 @@ func TestSameNumber_Fail(t *testing.T) {
 			expected: int(270), actuallyGot: int8(14), expectedFailReason: reason_NotSame,
 		},
 	} {
-		t.Run(tn, func(t *testing.T) {
-			stubConfirm(t, func() {
-				Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t)
-			}, tt.expectedFailReason)
-		})
+		stubConfirm(t, func() {
+			Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+		}, tt.expectedFailReason)
 	}
 }
 
@@ -206,10 +198,8 @@ func TestSameType_Fail(t *testing.T) {
 			expected: int32(5), actuallyGot: int64(5), expectedFailReason: reason_WrongType,
 		},
 	} {
-		t.Run(tn, func(t *testing.T) {
-			stubConfirm(t, func() {
-				Got(tt.actuallyGot).Expect(tt.expected).SameType(t)
-			}, tt.expectedFailReason)
-		})
+		stubConfirm(t, func() {
+			Got(tt.actuallyGot).Expect(tt.expected).SameType(t, tn)
+		}, tt.expectedFailReason)
 	}
 }

--- a/same_test.go
+++ b/same_test.go
@@ -46,7 +46,9 @@ func TestSame(t *testing.T) {
 			expected: struct{ bar string }{bar: "foo"}, actuallyGot: struct{ bar string }{bar: "foo"},
 		},
 	} {
-		Got(tt.actuallyGot).Expect(tt.expected).Same(t, tn)
+		t.Run(tn, func(t *testing.T) {
+			Got(tt.actuallyGot).Expect(tt.expected).Same(t)
+		})
 	}
 
 	// `foo` and `bar` are same value. But these pointer addresses are different in fact.
@@ -86,9 +88,11 @@ func TestSame_Fail(t *testing.T) {
 			expected: func() {}, actuallyGot: func() {}, expectedFailReason: reason_GotIsFunc,
 		},
 	} {
-		stubConfirm(t, func() {
-			Got(tt.actuallyGot).Expect(tt.expected).Same(t, tn)
-		}, tt.expectedFailReason)
+		t.Run(tn, func(t *testing.T) {
+			stubConfirm(t, func() {
+				Got(tt.actuallyGot).Expect(tt.expected).Same(t)
+			}, tt.expectedFailReason)
+		})
 	}
 }
 
@@ -140,7 +144,9 @@ func TestSameNumber(t *testing.T) {
 		// 	expected: complex64(1e+10 + 1e+10i), actuallyGot: complex128(1e+10 + 1e+10i),
 		// },
 	} {
-		Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+		t.Run(tn, func(t *testing.T) {
+			Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+		})
 	}
 
 	// test name
@@ -168,9 +174,11 @@ func TestSameNumber_Fail(t *testing.T) {
 			expected: int(270), actuallyGot: int8(14), expectedFailReason: reason_NotSame,
 		},
 	} {
-		stubConfirm(t, func() {
-			Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
-		}, tt.expectedFailReason)
+		t.Run(tn, func(t *testing.T) {
+			stubConfirm(t, func() {
+				Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+			}, tt.expectedFailReason)
+		})
 	}
 }
 
@@ -198,8 +206,10 @@ func TestSameType_Fail(t *testing.T) {
 			expected: int32(5), actuallyGot: int64(5), expectedFailReason: reason_WrongType,
 		},
 	} {
-		stubConfirm(t, func() {
-			Got(tt.actuallyGot).Expect(tt.expected).SameType(t, tn)
-		}, tt.expectedFailReason)
+		t.Run(tn, func(t *testing.T) {
+			stubConfirm(t, func() {
+				Got(tt.actuallyGot).Expect(tt.expected).SameType(t, tn)
+			}, tt.expectedFailReason)
+		})
 	}
 }

--- a/same_util.go
+++ b/same_util.go
@@ -9,7 +9,7 @@ import (
 )
 
 func reportForSame(a *TestingA) *w.Witness {
-	r := w.Expect(a.expect).Got(a.got)
+	r := w.Expect(a.expect).Got(a.got).Name(a.name)
 	if a.showRawData {
 		r = r.ShowRaw()
 	}


### PR DESCRIPTION
Improve test name in fail report.

Before

```
    foo.go:123:
                Test name:      TestFuncName
```

After

```
    foo.go:123:
                Test name:      TestFuncName/test name
```

Show "test name" that was specified in test.