### PR TITLE
Add shortcut method to witness in order to build fail report without assertion

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -1,6 +1,10 @@
 package actually
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/bayashi/witness"
+)
 
 // Actual is an alias of Got.
 func Actual(g any) *TestingA {
@@ -30,4 +34,9 @@ func (a *TestingA) Fatal() *TestingA {
 // FatalOn is an alias of FailNowOn.
 func FatalOn(t *testing.T) {
 	FailNowOn(t)
+}
+
+// Fatal is an alias of FailNow
+func Fatal(t *testing.T, reason string, got any, expect ...any) {
+	witness.FailNow(t, reason, got, expect...)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -114,3 +114,23 @@ func (a *TestingA) Name(n string) *TestingA {
 func Diff(a any, b any) string {
 	return witness.Diff(a, b)
 }
+
+// Fail is to show decorated fail report. (Actual shortcut to witness.Fail)
+/*
+	if g != e {
+		actually.Fail(t, "Not same", g, e)
+	}
+*/
+func Fail(t *testing.T, reason string, got any, expect ...any) {
+	witness.Fail(t, reason, got, expect...)
+}
+
+// FailNow is to show decorated fail report by t.Fatal. (Actual shortcut to witness.FailNow)
+/*
+	if g != e {
+		actually.FailNow(t, "Not same", g, e)
+	}
+*/
+func FailNow(t *testing.T, reason string, got any, expect ...any) {
+	witness.FailNow(t, reason, got, expect...)
+}


### PR DESCRIPTION
Sometimes, want only reporting feature.