### PR TITLE
rename `SameNumber` method to `SameConvertibleNumber` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func Test(t *testing.T) {
 
     // Assert 2 objects
     a.Got(love).Expect(true).Same(t)
-    a.Got(int32(1)).Expect(float64(1.0)).SameNumber(t)
+    a.Got(int32(1)).Expect(float64(1.0)).SameConvertibleNumber(t)
 
     heart := &love
     body  := heart
@@ -57,7 +57,7 @@ NOTE that `Got()` and `Expect()` should NOT be called multiple times in one chai
 
 ### [Assertion for 2 objects](https://github.com/bayashi/actually/wiki/All-assertion-methods#assertion-for-2-objects)
 
-* Same, SameNumber, SamePointer, SameType, NotSame, NotSameNumber, NotSamePointer, NotSameType
+* Same, SameConvertibleNumber, SamePointer, SameType, NotSame, NotSameConvertibleNumber, NotSamePointer, NotSameType
 
 ### [Assertion for panic](https://github.com/bayashi/actually/wiki/All-assertion-methods#assertion-for-panic)
 

--- a/assert_not_same.go
+++ b/assert_not_same.go
@@ -66,8 +66,13 @@ func (a *testingA) NotSamePointer(t *testing.T, testNames ...string) *testingA {
 	return a
 }
 
-// NotSameNumber method verifies that two objects are not same number.
+// Deprecated: Use `NotSameConvertibleNumber` instead. The `NotSameNumber` method will be removed.
 func (a *testingA) NotSameNumber(t *testing.T, testNames ...string) *testingA {
+	return a.NotSameConvertibleNumber(t, testNames...)
+}
+
+// NotSameConvertibleNumber method verifies that two objects are not same number.
+func (a *testingA) NotSameConvertibleNumber(t *testing.T, testNames ...string) *testingA {
 	invalidCallForSame(a)
 	a.name = a.naming(testNames...)
 	a.t = t
@@ -77,20 +82,20 @@ func (a *testingA) NotSameNumber(t *testing.T, testNames ...string) *testingA {
 	expect := a.expect
 
 	if isTypeNil(got) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_GotIsNilType)
 	}
 	if isTypeNil(expect) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_ExpectIsNilType)
 	}
 
 	if !isTypeNumber(got) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_GotIsNotNumber)
 	}
 	if !isTypeNumber(expect) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_ExpectIsNotNumber)
 	}
 

--- a/assert_not_same_test.go
+++ b/assert_not_same_test.go
@@ -72,16 +72,16 @@ func TestNotSamePointer_Fail(t *testing.T) {
 	}, reason_SamePointerAddress)
 }
 
-func TestNotSameNumber(t *testing.T) {
-	Got(1).Expect(2).NotSameNumber(t, "these should be different number")
-	Got(int8(1)).Expect(int32(2)).NotSameNumber(t)
-	Got(float32(1.1)).Expect(int64(1)).NotSameNumber(t)
+func TestNotSameConvertibleNumber(t *testing.T) {
+	Got(1).Expect(2).NotSameConvertibleNumber(t, "these should be different number")
+	Got(int8(1)).Expect(int32(2)).NotSameConvertibleNumber(t)
+	Got(float32(1.1)).Expect(int64(1)).NotSameConvertibleNumber(t)
 
 	// NOTE: Be aware of a result of test to compare int value with float value
-	Got(1).Expect(float64(1.000000000000001)).NotSameNumber(t)
+	Got(1).Expect(float64(1.000000000000001)).NotSameConvertibleNumber(t)
 }
 
-func TestNotSameNumber_Fail(t *testing.T) {
+func TestNotSameConvertibleNumber_Fail(t *testing.T) {
 	for tn, tt := range map[testName]testCase{
 		"same number": {
 			expected: 1, actuallyGot: 1, expectedFailReason: reason_Same,
@@ -104,7 +104,7 @@ func TestNotSameNumber_Fail(t *testing.T) {
 	} {
 		t.Run(tn, func(t *testing.T) {
 			stubConfirm(t, func() {
-				Got(tt.actuallyGot).Expect(tt.expected).NotSameNumber(t)
+				Got(tt.actuallyGot).Expect(tt.expected).NotSameConvertibleNumber(t)
 			}, tt.expectedFailReason)
 		})
 	}

--- a/assert_same.go
+++ b/assert_same.go
@@ -64,14 +64,19 @@ func (a *testingA) SamePointer(t *testing.T, testNames ...string) *testingA {
 	return a
 }
 
-// SameNumber method verifies that each pair of numbers are same or
+// Deprecated: Use `SameConvertibleNumber` instead. The `SameNumber` method will be removed.
+func (a *testingA) SameNumber(t *testing.T, testNames ...string) *testingA {
+	return a.SameConvertibleNumber(t, testNames...)
+}
+
+// SameConvertibleNumber method verifies that each pair of numbers are same or
 // convertible to the same types and converted objects are equal. (i.e. int* and float*)
 /*
-	Pass: actually.Got(float32(1.0)).Expect(int64(1)).SameNumber(t)
-	Fail: actually.Got("1").Expect(1).SameNumber(t) // string cannot convert to int
-	      actually.Got(nil).Expect(0).SameNumber(t) // <nil> is not acceptable
+	Pass: actually.Got(float32(1.0)).Expect(int64(1)).SameConvertibleNumber(t)
+	Fail: actually.Got("1").Expect(1).SameConvertibleNumber(t) // string cannot convert to int
+	      actually.Got(nil).Expect(0).SameConvertibleNumber(t) // <nil> is not acceptable
 */
-func (a *testingA) SameNumber(t *testing.T, testNames ...string) *testingA {
+func (a *testingA) SameConvertibleNumber(t *testing.T, testNames ...string) *testingA {
 	invalidCallForSame(a)
 	a.name = a.naming(testNames...)
 	a.t = t
@@ -80,20 +85,20 @@ func (a *testingA) SameNumber(t *testing.T, testNames ...string) *testingA {
 	got, expect := a.got, a.expect
 
 	if isTypeNil(got) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_GotIsNilType)
 	}
 	if isTypeNil(expect) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_ExpectIsNilType)
 	}
 
 	if !isTypeNumber(got) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_GotIsNotNumber)
 	}
 	if !isTypeNumber(expect) {
-		w := reportForSame(a).Message(notice_Label, notice_SameNumber_ShouldNumber)
+		w := reportForSame(a).Message(notice_Label, notice_SameConvertibleNumber_ShouldNumber)
 		return a.fail(w, reason_ExpectIsNotNumber)
 	}
 

--- a/assert_same_test.go
+++ b/assert_same_test.go
@@ -129,7 +129,7 @@ func TestSamePointer_Fail(t *testing.T) {
 	}, reason_WrongPointerAddress)
 }
 
-func TestSameNumber(t *testing.T) {
+func TestSameConvertibleNumber(t *testing.T) {
 	for tn, tt := range map[testName]testCase{
 		"same number": {
 			expected: 1, actuallyGot: 1,
@@ -145,15 +145,15 @@ func TestSameNumber(t *testing.T) {
 		// },
 	} {
 		t.Run(tn, func(t *testing.T) {
-			Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+			Got(tt.actuallyGot).Expect(tt.expected).SameConvertibleNumber(t, tn)
 		})
 	}
 
 	// test name
-	Got(1).Expect(1).SameNumber(t, "Same Number")
+	Got(1).Expect(1).SameConvertibleNumber(t, "Same Number")
 }
 
-func TestSameNumber_Fail(t *testing.T) {
+func TestSameConvertibleNumber_Fail(t *testing.T) {
 	for tn, tt := range map[testName]testCase{
 		"expected is not number": {
 			expected: "1", actuallyGot: 1, expectedFailReason: reason_ExpectIsNotNumber,
@@ -176,7 +176,7 @@ func TestSameNumber_Fail(t *testing.T) {
 	} {
 		t.Run(tn, func(t *testing.T) {
 			stubConfirm(t, func() {
-				Got(tt.actuallyGot).Expect(tt.expected).SameNumber(t, tn)
+				Got(tt.actuallyGot).Expect(tt.expected).SameConvertibleNumber(t, tn)
 			}, tt.expectedFailReason)
 		})
 	}
@@ -184,7 +184,7 @@ func TestSameNumber_Fail(t *testing.T) {
 
 func TestChain(t *testing.T) {
 	Got(7).NotNil(t).
-		Expect(7).SameNumber(t).Same(t)
+		Expect(7).SameConvertibleNumber(t).Same(t)
 }
 
 func TestSameType(t *testing.T) {

--- a/constants.go
+++ b/constants.go
@@ -45,11 +45,11 @@ const (
 	reason_ExpectNoPanic         = "Expected no panic, but did panic"
 
 	// notice_Method_*
-	notice_Label                        = "Notice"
-	notice_Same_NotAcceptable           = "It's not acceptable in Same() method"
-	notice_SamePointer_ShouldPointer    = "It should be a Pointer for SamePointer() method"
-	notice_SameNumber_ShouldNumber      = "It should be a number(int or float) for SameNumber() method"
-	notice_NotSamePointer_ShouldPointer = "It should be a Pointer for NotSamePointer() method"
+	notice_Label                              = "Notice"
+	notice_Same_NotAcceptable                 = "It's not acceptable in Same() method"
+	notice_SamePointer_ShouldPointer          = "It should be a Pointer for SamePointer() method"
+	notice_SameConvertibleNumber_ShouldNumber = "It should be a number(int or float) for SameConvertibleNumber() method"
+	notice_NotSamePointer_ShouldPointer       = "It should be a Pointer for NotSamePointer() method"
 
 	gotFunc_Label = "Got func"
 )


### PR DESCRIPTION
To specify what/how the func verifies