### PR TITLE
[Breaking Changes] tidied up the FailNow and Fatal method-related code

### DIFF
--- a/actually_util_test.go
+++ b/actually_util_test.go
@@ -7,6 +7,18 @@ import (
 )
 
 func TestFail(t *testing.T) {
+	{
+		a := FailNow()
+		if *a.failNow != true {
+			t.Errorf("`FailNow()` was broken. Expected:%#v, but Actual:%#v", true, a.failNow)
+		}
+
+		a = FailNotNow()
+		if *a.failNow != false {
+			t.Errorf("`FailNotNow()` was broken. Expected:%#v, but Actual:%#v", false, a.failNow)
+		}
+	}
+
 	a := Got(nil)
 	if a.failNow != nil && *a.failNow != false {
 		t.Errorf("Default failNow is false, but Actual:%#v", a.failNow)

--- a/aliases.go
+++ b/aliases.go
@@ -1,11 +1,5 @@
 package actually
 
-import (
-	"testing"
-
-	"github.com/bayashi/actually/witness"
-)
-
 // Actual is an alias of Got.
 func Actual(g any) *testingA {
 	return Got(g)
@@ -24,19 +18,4 @@ func Want(e any) *testingA {
 // Want is an alias of Expect.
 func (a *testingA) Want(e any) *testingA {
 	return a.Expect(e)
-}
-
-// Fatal is an alias of FailNow.
-func (a *testingA) Fatal() *testingA {
-	return a.FailNow()
-}
-
-// FatalOn is an alias of FailNowOn.
-func FatalOn(t *testing.T) {
-	FailNowOn(t)
-}
-
-// Fatal is an alias of FailNow
-func Fatal(t *testing.T, reason string, got any, expect ...any) {
-	witness.FailNow(t, reason, got, expect...)
 }

--- a/aliases_test.go
+++ b/aliases_test.go
@@ -1,7 +1,6 @@
 package actually
 
 import (
-	"os"
 	"testing"
 )
 
@@ -28,22 +27,5 @@ func TestWant(t *testing.T) {
 	ac.Want("E")
 	if ac.expect != "E" {
 		t.Errorf("Want method was wrong. Actually got %s", ac.expect)
-	}
-}
-
-func TestFatal(t *testing.T) {
-	a := Got("g").Fatal()
-	if !*a.failNow {
-		t.Error("expect failNow is false")
-	}
-}
-
-func TestFatalOn(t *testing.T) {
-	if os.Getenv(envKey_FailNow) != "" {
-		t.Error("Already set ENV somehow")
-	}
-	FatalOn(t)
-	if os.Getenv(envKey_FailNow) == "" {
-		t.Error("expect failNow is false")
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -17,10 +17,14 @@ func failNowPtr(v bool) *bool {
 }
 
 // `FailNow` turns a flag on to stop further test execution immediately if one test fails.
-// NOTE that FailNow method should be called after `Got` or `Expect`.
 /*
 	actually.Got(something).FailNow().Nil(t) // Fail now for only this test
 */
+func FailNow() *testingA {
+	return &testingA{
+		failNow: failNowPtr(true),
+	}
+}
 func (a *testingA) FailNow() *testingA {
 	a.failNow = failNowPtr(true)
 
@@ -71,9 +75,13 @@ func FailNotNowOn(t *testing.T) {
 // FailNotNow turns a flag off, so that even if the test fails, execution does not stop immediately.
 /*
    It behaves this way by default. If you want the opposite behavior, call `FailNow` method.
-   NOTE that FailNotNow method should be called after `Got` or `Expect`.
 */
 // Deprecated: Anyone uses? This method will be removed in the near future.
+func FailNotNow() *testingA {
+	return &testingA{
+		failNow: failNowPtr(false),
+	}
+}
 func (a *testingA) FailNotNow() *testingA {
 	a.failNow = failNowPtr(false)
 
@@ -179,13 +187,13 @@ func Fail(t *testing.T, reason string, got any, expect ...any) {
 	witness.Fail(t, reason, got, expect...)
 }
 
-// FailNow is to show decorated fail report by t.Fatal. (Actual shortcut to witness.FailNow)
+// Fatal is to show decorated fail report by t.Fatal. (Actual shortcut to witness.FailNow)
 /*
 	if g != e {
 		actually.FailNow(t, "Not same", g, e)
 	}
 */
-func FailNow(t *testing.T, reason string, got any, expect ...any) {
+func Fatal(t *testing.T, reason string, got any, expect ...any) {
 	t.Helper()
 	witness.FailNow(t, reason, got, expect...)
 }


### PR DESCRIPTION
## Deprecated

**Breaking Changes**

Remove methods:

* `Fatal`: The alias of a.FailNow
* `FatalOn`: The alias of FailNowOn

(Keeping `Fatal` method as witness.FailNow wrapper)

## Renewed

* Add `FailNow` method and `FailNotNow` method to build `actually` instance, as straightforward
